### PR TITLE
Add ECEF->LLA conversion utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ To quickly clean up CMake output files, use `git clean -xdf`.
 
 The latest doxygen docs for the Open DIS master branch can be found [here](https://codedocs.xyz/open-dis/open-dis-cpp/).
 
+## Coordinate Conversion Utilities
+
+The `ConversionUtils` helper class offers basic functions for converting
+between different coordinate systems. In addition to the existing Euler angle
+helpers, it now provides `ecefToLla` for converting Earth-Centered
+Earth-Fixed (ECEF) coordinates to latitude, longitude and altitude. The
+function returns the latitude and longitude in radians and altitude in meters
+and reports failure when supplied with non-finite input values.
+
 ## SDL2 and SDL2_net Install Instructions
 
 ### Linux Package Managers

--- a/src/dis7/utils/ConversionUtils.cpp
+++ b/src/dis7/utils/ConversionUtils.cpp
@@ -73,4 +73,42 @@ double ConversionUtils::getRollFromEuler(double lat, double lon, double psi, dou
 
     return radToDeg(atan2(-b23, -b33));
 }
+
+bool ConversionUtils::ecefToLla(double x, double y, double z,
+                                double &lat, double &lon, double &alt)
+{
+    if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z))
+    {
+        lat = lon = alt = 0.0;
+        return false;
+    }
+
+    const double a = 6378137.0;             // WGS-84 semi-major axis
+    const double e2 = 6.69437999014e-3;     // first eccentricity squared
+
+    const double b = a * sqrt(1.0 - e2);
+    const double ep = sqrt((a * a - b * b) / (b * b));
+
+    const double p = sqrt(x * x + y * y);
+    if (p < 1e-9)
+    {
+        lon = 0.0;
+        lat = (z >= 0.0 ? PI / 2.0 : -PI / 2.0);
+        alt = fabs(z) - b;
+        return true;
+    }
+
+    lon = atan2(y, x);
+    const double th = atan2(a * z, b * p);
+    const double sin_th = sin(th);
+    const double cos_th = cos(th);
+    lat = atan2(z + ep * ep * b * sin_th * sin_th * sin_th,
+                p - e2 * a * cos_th * cos_th * cos_th);
+
+    const double sin_lat = sin(lat);
+    const double N = a / sqrt(1.0 - e2 * sin_lat * sin_lat);
+    alt = p / cos(lat) - N;
+
+    return std::isfinite(lat) && std::isfinite(lon) && std::isfinite(alt);
+}
 } // namespace DIS

--- a/src/dis7/utils/ConversionUtils.h
+++ b/src/dis7/utils/ConversionUtils.h
@@ -61,6 +61,20 @@ public:
      */
     static double getRollFromEuler(double lat, double lon, double psi, double theta, double phi);
 
+    /**
+     * @brief Convert Earth-Centered Earth-Fixed coordinates to latitude,
+     * longitude and altitude.
+     * @param x ECEF X coordinate in meters
+     * @param y ECEF Y coordinate in meters
+     * @param z ECEF Z coordinate in meters
+     * @param lat Latitude result expressed in radians
+     * @param lon Longitude result expressed in radians
+     * @param alt Altitude result in meters
+     * @return true if the conversion was successful
+     */
+    static bool ecefToLla(double x, double y, double z,
+                          double &lat, double &lon, double &alt);
+
     static double radToDeg(double rad) { return rad * (180 / PI); };
     static double degToRad(double deg) { return deg * (PI / 180); };
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(unit_test_suite_src
   IncomingMessageTests.cpp
   PduMarshallTests.cpp
   PduUtils.cpp
+  ConversionUtilsTests.cpp
 )
 
 add_executable(
@@ -11,7 +12,7 @@ add_executable(
   ${unit_test_suite_src}
 )
 
-target_link_libraries(UnitTestSuite OpenDIS6)
+target_link_libraries(UnitTestSuite OpenDIS6 OpenDIS7)
 target_include_directories(UnitTestSuite PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME UnitTestSuite

--- a/test/ConversionUtilsTests.cpp
+++ b/test/ConversionUtilsTests.cpp
@@ -1,0 +1,25 @@
+#include "catch.hpp"
+#include <limits>
+#include <dis7/utils/ConversionUtils.h>
+
+TEST_CASE("ECEF to LLA conversion", "[ConversionUtils]") {
+  double lat = 0.0;
+  double lon = 0.0;
+  double alt = 0.0;
+  bool ok = DIS::ConversionUtils::ecefToLla(6378137.0, 0.0, 0.0, lat, lon, alt);
+  REQUIRE(ok);
+  REQUIRE(lat == Approx(0.0).margin(1e-6));
+  REQUIRE(lon == Approx(0.0).margin(1e-6));
+  REQUIRE(alt == Approx(0.0).margin(1e-3));
+}
+
+TEST_CASE("ECEF to LLA invalid input", "[ConversionUtils]") {
+  double lat = 1.0;
+  double lon = 1.0;
+  double alt = 1.0;
+  bool ok = DIS::ConversionUtils::ecefToLla(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0, lat, lon, alt);
+  REQUIRE_FALSE(ok);
+  REQUIRE(lat == 0.0);
+  REQUIRE(lon == 0.0);
+  REQUIRE(alt == 0.0);
+}


### PR DESCRIPTION
## Summary
- expose `ecefToLla` conversion in `ConversionUtils`
- test ECEF->LLA calculations
- link tests with OpenDIS7
- document coordinate conversion helpers in README

## Testing
- `cmake .. -DBUILD_TESTS=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_683f918566ac83298339ab45b9eb39c1